### PR TITLE
fix: potential fix for code scanning alert no. 1: Unvalidated dynamic method call

### DIFF
--- a/pwa/js/router.js
+++ b/pwa/js/router.js
@@ -24,8 +24,8 @@ class Router {
     async navigate(path) {
         const handler = this.routes[path];
         
-        if (!handler) {
-            console.error(`Route not found: ${path}`);
+        if (!handler || typeof handler !== 'function') {
+            console.error(`Route not found or invalid handler for path: ${path}`);
             return;
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/jry25/gestion-tir-arc-fscf/security/code-scanning/1](https://github.com/jry25/gestion-tir-arc-fscf/security/code-scanning/1)

In general, to fix unvalidated dynamic method calls, you must validate that the looked-up property is an allowed, callable function before invoking it. For a router like this, that means ensuring that the value retrieved from `this.routes[path]` is of type `"function"` before calling/awaiting it, and handling the case where it is not.

The best minimal change here is to augment the existing `if (!handler)` guard in `navigate` with a type check. Specifically, after retrieving `handler = this.routes[path]`, check both that `handler` exists and that `typeof handler === 'function'`. If either condition fails, log an error and return without invoking it. This preserves current functionality for valid routes, while preventing runtime exceptions if a non-function value is ever stored in `this.routes` under a user-controlled key. No new imports or files are needed; the change is local to the `navigate` method in `pwa/js/router.js`.

Concretely:
- In `navigate(path)`, change the `if (!handler)` block to also verify `typeof handler === 'function'`.
- Optionally, improve the error message to mention that the route handler is invalid when it’s not a function.
- Keep the rest of the logic (updating navigation, setting `currentPage`, awaiting the handler) unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
